### PR TITLE
require unsigned char *

### DIFF
--- a/Crypto.cpp
+++ b/Crypto.cpp
@@ -90,7 +90,7 @@ int Crypto::generateAesKey(unsigned char **aesKey, unsigned char **aesIv) {
   *aesKey = (unsigned char*)malloc(aesKeyLength);
   *aesIv = (unsigned char*)malloc(aesIvLength);
 
-  if(aesKey == NULL || aesIv == NULL) {
+  if(*aesKey == NULL || *aesIv == NULL) {
     return FAILURE;
   }
 

--- a/Crypto.cpp
+++ b/Crypto.cpp
@@ -113,7 +113,7 @@ int Crypto::generateAesKey(unsigned char **aesKey, unsigned char **aesIv) {
       return FAILURE;
     }
 
-    if(EVP_BytesToKey(EVP_aes_256_cbc(), EVP_sha256(), aesSalt, aesPass, aesKeyLength, AES_ROUNDS, aesKey, aesIv) == 0) {
+    if(EVP_BytesToKey(EVP_aes_256_cbc(), EVP_sha256(), aesSalt, aesPass, aesKeyLength, AES_ROUNDS, *aesKey, *aesIv) == 0) {
       return FAILURE;
     }
 


### PR DESCRIPTION
g++ -Wall -Wextra -ggdb -DUSE_PBKDF -o crypto_example base64.cpp Crypto.cpp crypto_example.cpp -lcrypto
Crypto.cpp: 在成员函数‘int Crypto::generateAesKey(unsigned char**, unsigned char**)’中:
Crypto.cpp:116:113: erroe ：不能将 ‘int EVP_BytesToKey(const EVP_CIPHER*, const EVP_MD*, const unsigned char*, const unsigned char*, int, int, unsigned char*, unsigned char*)’的实参‘7’从‘unsigned char**’转换到‘unsigned char*’
